### PR TITLE
Add embedded Google Maps preview to property location

### DIFF
--- a/src/crm/pages/PropertyDetailPage.tsx
+++ b/src/crm/pages/PropertyDetailPage.tsx
@@ -923,7 +923,8 @@ export default function PropertyDetailPage({
                   position: 'relative',
                   overflow: 'hidden',
                   border: '1px solid',
-                  borderColor: 'divider'
+                  borderColor: 'divider',
+                  mb: 2
                 }}>
                   <iframe
                     src={`https://www.google.com/maps?q=${encodeURIComponent(property.address)}&output=embed&z=15`}
@@ -936,6 +937,28 @@ export default function PropertyDetailPage({
                     title={`Map showing ${property.address}`}
                   />
                 </Box>
+                <Stack direction="row" spacing={1} justifyContent="center">
+                  <Button
+                    variant="contained"
+                    size="small"
+                    startIcon={<LaunchRoundedIcon />}
+                    onClick={() => {
+                      window.open(`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(property.address)}`, '_blank');
+                    }}
+                  >
+                    Open in Maps
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<DirectionsRoundedIcon />}
+                    onClick={() => {
+                      window.open(`https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(property.address)}`, '_blank');
+                    }}
+                  >
+                    Get Directions
+                  </Button>
+                </Stack>
                 <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
                   ���� {property.address}
                 </Typography>


### PR DESCRIPTION
## Purpose

The user requested to add a Google Maps preview directly within the property location page instead of requiring users to click a button to open the map externally. They wanted to see the map preview before deciding to open it in full Google Maps, while still maintaining the option to open Google Maps externally if desired.

## Code changes

- **Replaced placeholder location display** with embedded Google Maps iframe showing the property address
- **Added embedded map preview** using Google Maps embed API with proper encoding of the property address
- **Maintained external map buttons** for "Open in Maps" and "Get Directions" functionality
- **Updated styling** to remove placeholder background and center the action buttons below the map
- **Added proper iframe attributes** including accessibility title, lazy loading, and security policies

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 49`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c2f17b92e6d841afb7fc7b6e74cf7fa4/cosmos-haven)

👀 [Preview Link](https://c2f17b92e6d841afb7fc7b6e74cf7fa4-cosmos-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c2f17b92e6d841afb7fc7b6e74cf7fa4</projectId>-->
<!--<branchName>cosmos-haven</branchName>-->